### PR TITLE
Typo fixed on Line 36. Should read req.method instead of req.methos

### DIFF
--- a/lib/middleware/request-logger.js
+++ b/lib/middleware/request-logger.js
@@ -33,7 +33,7 @@ module.exports = function(options) {
 			req: {
 				url: req.url,
 				originalUrl: req.originalUrl,
-				method: req.methos,
+				method: req.method,
 				httpVersion: req.httpVersion,
 				headers: req.headers,
 				query: req.query,


### PR DESCRIPTION
Typo causes Method not to be printed out in if Meta option set to true.